### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2007- Clive Crous
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/remarkably/version.rb
+++ b/lib/remarkably/version.rb
@@ -1,3 +1,3 @@
 module Remarkably
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end

--- a/remarkably.gemspec
+++ b/remarkably.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://www.darkarts.co.za/remarkably"
   s.summary     = %q{A very tiny Markaby-like XML,HTML and CSS builder}
   s.description = %q{Remarkably is a very tiny Markaby-like XML,HTML and CSS builder}
+  s.license     = "MIT"
 
   s.add_development_dependency "bundler", ">= 1.0.0"
   s.add_development_dependency "rake", ">= 0.8.7"


### PR DESCRIPTION
Hi Clive,

This piece of software is a pretty critical piece of software for a lot of open-source projects out there (e.g. webmock, minitest, rake, mocha). Because it lacks a license, however, a lot of projects downstream are unable to use those projects (and this one, too).

I added the MIT license, but please feel free to change it to whatever makes sense. I also bumped the version so that `0.6.2` can get released with the license information.